### PR TITLE
use foundry stable version

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,6 +17,8 @@ jobs:
           submodules: recursive
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration file `.github/workflows/test.yaml`. The change updates the version of the Foundry toolchain used in the workflow from `nightly` to `stable`.

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L27-R27): Changed the Foundry toolchain version from `nightly` to `stable` to ensure more stable builds.