### PR TITLE
fix: resolve zizmor GitHub Actions security findings

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main, master, staging, dev, feat/**, fix/**]
 
+permissions: {}
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -13,6 +14,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
 env:
   FOUNDRY_PROFILE: ${{ github.event_name == 'push' && 'ci' || 'pr' }}
 
+permissions: {}
 jobs:
   forge-test:
     strategy:
@@ -21,6 +22,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: TruffleHog OSS
         id: trufflehog


### PR DESCRIPTION
## Summary
- Ran zizmor static analysis on GitHub Actions workflows
- Fixed credential persistence issues (persist-credentials: false)
- Added minimal permissions blocks where missing
- Fixed template injection vulnerabilities where auto-fixable

Generated by zizmor v1.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)